### PR TITLE
[CONTID-11148] Remove dependabot github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,20 +25,3 @@ updates:
         update-types: ["version-update:semver-major"]
         
   # Enable version updates for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "04:00"
-    cooldown:
-      default-days: 7
-    open-pull-requests-limit: 5
-    reviewers:
-      - "SGNL-ai/engineering"
-    labels:
-      - "dependencies"
-      - "github-actions"
-    commit-message:
-      prefix: "ci"
-      include: "scope"


### PR DESCRIPTION
Remove github-actions package ecosystem from Dependabot configuration.

GHA versions are explicitly allowlisted and AppSec will reach out when specific vulnerabilities need updates.

Jira: https://jira.cs.sys/browse/CONTID-11148

LLM Agent(s) contributed to this PR.