### PR TITLE
chore: remove codecov workflow step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,6 @@ jobs:
       - name: Run tests with coverage
         run: npm run test:coverage
 
-      - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20.x'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage/lcov.info
-          fail_ci_if_error: false
-
   build:
     name: Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Removes the Codecov upload step from `.github/workflows/ci.yml`.
- `CODECOV_TOKEN` (CI environment secret) is unused after this change and will be deleted separately.

## Test plan
- [ ] Confirm CI workflow runs and passes without the Codecov step.

LLM Agent(s) contributed to this PR.